### PR TITLE
Fix comma-dangle to require comma in multiline arrays and objects

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+   "extends": "./index.js"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+   - '4.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
    - '4.5'
+before_script:
+   - npm install -g grunt
+script:
+   - grunt standards

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = function(grunt) {
+
+   grunt.initConfig({
+
+      pkg: grunt.file.readJSON('package.json'),
+
+      eslint: {
+         target: [ '**/*.js', '!node_modules/**/*' ],
+      },
+
+   });
+
+   grunt.loadNpmTasks('grunt-eslint');
+
+   grunt.registerTask('standards', [ 'eslint' ]);
+   grunt.registerTask('default', [ 'standards' ]);
+
+};

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = {
       'silvermine/no-multiline-var-declarations': 'error',
       'silvermine/indent': [ 'error', 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 }, 'SwitchCase': 1 } ],
 
-      'comma-dangle': [ 'error', 'only-multiline' ],
+      'comma-dangle': [ 'error', 'never' ],
       'no-unsafe-finally': 'warn',
 
       'array-callback-return': 'error',
@@ -122,7 +122,7 @@ module.exports = {
             'overrides': {
                'catch': { 'after': false },
             },
-         }
+         },
       ],
       'linebreak-style': [ 'error', 'unix' ],
       'lines-around-comment': 'error',
@@ -132,14 +132,14 @@ module.exports = {
          {
             'code': 140,
             'ignoreUrls': true,
-         }
+         },
       ],
       'max-nested-callbacks': [ 'error', 6 ],
       'max-params': [ 'error', 5 ],
       'max-statements-per-line': 'error',
       'new-cap': [
          'error',
-         { 'capIsNewExceptions': [ 'Q' ] }
+         { 'capIsNewExceptions': [ 'Q' ] },
       ],
       'new-parens': 'error',
       'newline-after-var': 'error',
@@ -152,14 +152,14 @@ module.exports = {
             'max': 2,
             'maxBOF': 0,
             'maxEOF': 0,
-         }
+         },
       ],
       'no-negated-condition': 'error',
       'no-nested-ternary': 'error',
       'no-new-object': 'error',
       'no-plusplus': [
          'error',
-         { 'allowForLoopAfterthoughts': true }
+         { 'allowForLoopAfterthoughts': true },
       ],
       'no-restricted-syntax': [
          'error',
@@ -185,7 +185,7 @@ module.exports = {
          'JSXSpreadAttribute',
          'JSXText',
          'WithStatement',
-         'YieldExpression'
+         'YieldExpression',
       ],
       'no-spaced-func': 'error',
       'no-trailing-spaces': 'error',

--- a/node.js
+++ b/node.js
@@ -13,4 +13,7 @@ module.exports = {
 
    'extends': './index.js',
 
+   'rules': {
+      'comma-dangle': [ 'error', 'always-multiline' ],
+   },
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "eslint-plugin-silvermine": "1.0.2"
   },
   "devDependencies": {
-    "eslint": "2.11.1"
+    "eslint": "2.11.1",
+    "grunt": "1.0.1",
+    "grunt-eslint": "19.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "JS Code Standards for all SilverMine projects - eslint enforcement",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The comma-dangle rule was set to only-multiline. This setting does not require a comma in multi-line, it only disallows a trailing comma in single line objects and arrays.

I changed the setting to always-multiline to better fit our coding standards.