### PR TITLE
Add Travis Config, eslint and grunt

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+   "extends": "./index.js"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+   - '4.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
    - '4.5'
+before_script:
+   - npm install -g grunt
+script:
+   - grunt standards

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = function(grunt) {
+
+   grunt.initConfig({
+
+      pkg: grunt.file.readJSON('package.json'),
+
+      eslint: {
+         target: [ '**/*.js', '!node_modules/**/*' ],
+      },
+
+   });
+
+   grunt.loadNpmTasks('grunt-eslint');
+
+   grunt.registerTask('standards', [ 'eslint' ]);
+   grunt.registerTask('default', [ 'standards' ]);
+
+};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "eslint-plugin-silvermine": "1.0.2"
   },
   "devDependencies": {
-    "eslint": "2.11.1"
+    "eslint": "2.11.1",
+    "grunt": "1.0.1",
+    "grunt-eslint": "19.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "JS Code Standards for all SilverMine projects - eslint enforcement",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Our travis ci builds were failing because we didn't have a .travis.yml file.

This PR adds the travis config. It also adds eslint checks using this configs rules by inheriting index.js in the eslintrc file.  To facilitate the eslint check, grunt was also added with the corresponding Gruntfile.