### PR TITLE
Add rule to require space before comment

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,6 +129,7 @@ module.exports = {
       ],
       'linebreak-style': [ 'error', 'unix' ],
       'lines-around-comment': 'error',
+      'spaced-comment': [ 'error', 'always' ],
       'max-depth': [ 'error', 4 ],
       'max-len': [
          'error',


### PR DESCRIPTION
Our standards state that there is a space at
the beginning of each comment, but the corresponding
ESLint rule was never enabled.

This adds `'spaced-comment': [ 'error', 'always' ]` to
our config.