### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_line = true
+
+indent_style = space
+indent_size = 3
+
+charset = utf-8


### PR DESCRIPTION
In order to have uniform editor settings across developer machines for
all our projects, we've decided to supply a standard .editorconfig file.
The most logical place to do this seems to be in our linting
configuration, since the settings mostly affect our linting. We can then
symlink the file to the root of each of our projects.

This commit adds the .editorconfig file.