### PR TITLE
Remove silvermine/indent rule and use base eslint indent rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,12 +37,12 @@ module.exports = {
       '@silvermine/silvermine/no-multiple-inline-functions': 'error',
       '@silvermine/silvermine/no-multiline-conditionals': 'error',
       '@silvermine/silvermine/no-multiline-var-declarations': [ 'error', { 'const': 'single-only' } ],
-      '@silvermine/silvermine/indent': [ 'error', 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 }, 'SwitchCase': 1 } ],
       '@silvermine/silvermine/empty-object-spacing': 'error',
       '@silvermine/silvermine/empty-array-spacing': 'error',
       '@silvermine/silvermine/uninitialized-last': 'error',
       '@silvermine/silvermine/block-scope-case': 'error',
 
+      'indent': [ 'error', 3, { 'VariableDeclarator': 'first', 'SwitchCase': 1 } ],
       'comma-dangle': [ 'error', 'always-multiline' ],
       'no-unsafe-finally': 'warn',
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,9 +294,9 @@
       }
     },
     "debug": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
         "ms": "^2.1.1"
@@ -339,9 +339,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.10.0.tgz",
-      "integrity": "sha512-HpqzC+BHULKlnPwWae9MaVZ5AXJKpkxCVXQHrFaRw3hbDj26V/9ArYM4Rr/SQ8pi6qUPLXSSXC4RBJlyq2Z2OQ==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.11.1.tgz",
+      "integrity": "sha512-gOKhM8JwlFOc2acbOrkYR05NW8M6DCMSvfcJiBB5NDxRE1gv8kbvxKaC9u69e6ZGEMWXcswA/7eKR229cEIpvg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "grunt-eslint": "21.0.0"
   },
   "peerDependencies": {
-    "eslint": "5.x"
+    "eslint": ">= 5.11.1"
   }
 }


### PR DESCRIPTION
A new option on the base eslint indent rule fixes the problem that
forced us to make a custom rule. We can now line up variable
declarations by using the "VariableDeclarator": "first" option.

To use this rule, we need to ensure a peer dependency of
eslint >= 5.11.1. Also, `grunt-eslint` needed to be re-installed to
update it's eslint dependency in the package-lock.json file (the same
version was used, but the eslint dependency pulled down the new version)