### PR TITLE
Add custom brace-style

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ module.exports = {
       '@silvermine/silvermine/empty-array-spacing': 'error',
       '@silvermine/silvermine/uninitialized-last': 'error',
       '@silvermine/silvermine/block-scope-case': 'error',
+      '@silvermine/silvermine/brace-style': [ 'error', '1tbs', { 'allowSingleLine': false, 'allowSingleLineArrow': true } ],
+
 
       'indent': [ 'error', 3, { 'VariableDeclarator': 'first', 'SwitchCase': 1 } ],
       'comma-dangle': [ 'error', 'always-multiline' ],
@@ -128,7 +130,6 @@ module.exports = {
 
       'array-bracket-spacing': [ 'error', 'always' ],
       'block-spacing': 'error',
-      'brace-style': 'error',
       'camelcase': 'error',
       'comma-spacing': 'error',
       'comma-style': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@silvermine/eslint-plugin-silvermine": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@silvermine/eslint-plugin-silvermine/-/eslint-plugin-silvermine-2.0.1.tgz",
-      "integrity": "sha512-JmQNik/Bw1e91vVgb/IEKzqCuzNB9Vga8TuiqJJgLw9rGcN+LWQRRzeFkpJuHBwMDNUaEzrv3HO/lzivpP3UZQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@silvermine/eslint-plugin-silvermine/-/eslint-plugin-silvermine-2.1.0.tgz",
+      "integrity": "sha512-G60GNFxIQKMkvbKbiKpP24OOl47iNRWc6g83bv8mWaQsEwRY5MIJPJVe1kjV8vM0HcFoyBmBWKa1xXVu7B8BMw==",
       "requires": {
         "class.extend": "0.9.2",
         "lodash.assign": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/silvermine/eslint-config-silvermine#readme",
   "dependencies": {
-    "@silvermine/eslint-plugin-silvermine": "2.0.1",
+    "@silvermine/eslint-plugin-silvermine": "2.1.0",
     "eslint-plugin-typescript": "0.14.0",
     "typescript": "3.0.3",
     "typescript-eslint-parser": "17.0.1"


### PR DESCRIPTION
This PR upgrades eslint-plugin-silvermine to 2.1.0 and uses the custom `brace-style` rule to allow single line arrow functions.