### PR TITLE
Fixes #36 Allow use of typedefs before they are defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,7 +294,13 @@ module.exports = {
 
             // Turn off the core no-use-before-define to avoid double reporting errors.
             'no-use-before-define': 'off',
-            'typescript/no-use-before-define': [ 'error', { 'functions': false } ],
+            'typescript/no-use-before-define': [
+               'error',
+               {
+                  'functions': false,
+                  'typedefs': false,
+               },
+            ],
 
             'typescript/no-type-alias': [
                'error',


### PR DESCRIPTION
In TypeScript, `type` definitions are hoisted, so it is valid to
reference a type that is declared later on in the file. We want to allow
this so that we can organize the types in a given file hierarchically.