### PR TITLE
Fixes #38 Use new @typescript-eslint projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
 
    'plugins': [
       '@silvermine/eslint-plugin-silvermine', // Our custom rules
-      'typescript', // TypeScript-specific rules
+      '@typescript-eslint', // TypeScript-specific rules
    ],
 
    'parserOptions': {
@@ -242,7 +242,7 @@ module.exports = {
    'overrides': [
       {
          'files': [ '*.ts' ],
-         'parser': 'eslint-plugin-typescript/parser',
+         'parser': '@typescript-eslint/parser',
          'parserOptions': {
             'sourceType': 'module',
             // Disable warning banner for possibly incompatible versions of TypeScript
@@ -262,7 +262,7 @@ module.exports = {
             'no-undef': 'off',
             // The standard ESLint `no-unused-vars' rule will throw false positives with
             // class properties in TypeScript. The TypeScript-specific rule fixes this.
-            'typescript/no-unused-vars': 'error',
+            '@typescript-eslint/no-unused-vars': 'error',
             // new-cap throws errors with property decorators
             'new-cap': 'off',
 
@@ -272,20 +272,20 @@ module.exports = {
 
             'no-empty-function': [ 'error', { 'allow': [ 'constructors' ] } ],
 
-            'typescript/adjacent-overload-signatures': 'error',
-            'typescript/class-name-casing': 'error',
-            'typescript/explicit-function-return-type': [ 'error', { 'allowExpressions': true } ],
-            'typescript/explicit-member-accessibility': 'error',
-            'typescript/member-delimiter-style': 'error',
-            'typescript/no-angle-bracket-type-assertion': 'error',
-            'typescript/no-array-constructor': 'error',
-            'typescript/no-namespace': 'error',
-            'typescript/member-naming': [ 'error', { 'private': '^_', 'protected': '^_' } ],
-            'typescript/member-ordering': 'error',
-            'typescript/no-non-null-assertion': 'error',
-            'typescript/no-parameter-properties': [ 'error', { 'allows': [ 'private' ] } ],
-            'typescript/no-triple-slash-reference': 'error',
-            'typescript/type-annotation-spacing': [
+            '@typescript-eslint/adjacent-overload-signatures': 'error',
+            '@typescript-eslint/class-name-casing': 'error',
+            '@typescript-eslint/explicit-function-return-type': [ 'error', { 'allowExpressions': true } ],
+            '@typescript-eslint/explicit-member-accessibility': 'error',
+            '@typescript-eslint/member-delimiter-style': 'error',
+            '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
+            '@typescript-eslint/no-array-constructor': 'error',
+            '@typescript-eslint/no-namespace': 'error',
+            '@typescript-eslint/member-naming': [ 'error', { 'private': '^_', 'protected': '^_' } ],
+            '@typescript-eslint/member-ordering': 'error',
+            '@typescript-eslint/no-non-null-assertion': 'error',
+            '@typescript-eslint/no-parameter-properties': [ 'error', { 'allows': [ 'private' ] } ],
+            '@typescript-eslint/no-triple-slash-reference': 'error',
+            '@typescript-eslint/type-annotation-spacing': [
                'error',
                {
                   'before': false,
@@ -295,11 +295,11 @@ module.exports = {
                   },
                },
             ],
-            'typescript/no-empty-interface': 'error',
+            '@typescript-eslint/no-empty-interface': 'error',
 
             // Turn off the core no-use-before-define to avoid double reporting errors.
             'no-use-before-define': 'off',
-            'typescript/no-use-before-define': [
+            '@typescript-eslint/no-use-before-define': [
                'error',
                {
                   'functions': false,
@@ -307,7 +307,7 @@ module.exports = {
                },
             ],
 
-            'typescript/no-type-alias': [
+            '@typescript-eslint/no-type-alias': [
                'error',
                {
                   'allowAliases': 'in-unions-and-intersections',
@@ -322,8 +322,8 @@ module.exports = {
 
          'rules': {
             'no-unused-vars': 'off',
-            'typescript/no-namespace': 'off',
-            'typescript/no-empty-interface': 'off',
+            '@typescript-eslint/no-namespace': 'off',
+            '@typescript-eslint/no-empty-interface': 'off',
          },
       },
    ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,42 @@
         "underscore": "1.8.3"
       }
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.2.0.tgz",
+      "integrity": "sha512-em3q8Gg3euesNohOwaz+SqrQM2Jn1ZWELMM+vgKi4dEk5fC+eVoi05yfubgAi2qPE5ifG4F0SOXM1XTamB0Aig==",
+      "requires": {
+        "@typescript-eslint/parser": "1.2.0",
+        "requireindex": "^1.2.0",
+        "tsutils": "^3.7.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-IXXiXgs6ocKTmtbzJjGyUvRHZFLuk2mYXyk+ayEql1woh1+rYS/Uct8b4jGtfHG8ZRUBZ12zjzsrDKFYC2pbrQ==",
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.2.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.2.0.tgz",
+      "integrity": "sha512-YGh4egbiCfUObvi6fnQNzJAMmScMGCjG5cRHaapW7GpwujWYQymLlids88imnhcTbOx8Mlz1OXFIuxyPBXK6Ig==",
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        }
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -381,15 +417,6 @@
         "strip-json-comments": "^2.0.1",
         "table": "^5.0.2",
         "text-table": "^0.2.0"
-      }
-    },
-    "eslint-plugin-typescript": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript/-/eslint-plugin-typescript-1.0.0-rc.2.tgz",
-      "integrity": "sha512-q/F2EOSPDeGgIwqZ5MgQmOpbhQjkuW7ko3M0fsXJ/2DUarG+ASfE9L1xzyfDtCMV3nFXd5EtypEnNawInXmpLg==",
-      "requires": {
-        "requireindex": "^1.2.0",
-        "typescript-eslint-parser": "21.0.2"
       }
     },
     "eslint-scope": {
@@ -1488,8 +1515,15 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "tsutils": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.8.0.tgz",
+      "integrity": "sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==",
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "type-check": {
       "version": "0.3.2",
@@ -1501,35 +1535,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
-      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ=="
-    },
-    "typescript-eslint-parser": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-21.0.2.tgz",
-      "integrity": "sha512-u+pj4RVJBr4eTzj0n5npoXD/oRthvfUCjSKndhNI714MG0mQq2DJw5WP7qmonRNIFgmZuvdDOH3BHm9iOjIAfg==",
-      "requires": {
-        "eslint-scope": "^4.0.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "typescript-estree": "5.3.0"
-      }
-    },
-    "typescript-estree": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-5.3.0.tgz",
-      "integrity": "sha512-Vu0KmYdSCkpae+J48wsFC1ti19Hq3Wi/lODUaE+uesc3gzqhWbZ5itWbsjylLVbjNW4K41RqDzSfnaYNbmEiMQ==",
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-        }
-      }
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.1.tgz",
+      "integrity": "sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA=="
     },
     "underscore": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@silvermine/eslint-plugin-silvermine": "2.1.0",
-    "eslint-plugin-typescript": "1.0.0-rc.2",
-    "typescript": "3.1.1"
+    "@typescript-eslint/eslint-plugin": "1.2.0",
+    "typescript": "3.3.1"
   },
   "devDependencies": {
     "grunt": "1.0.3",


### PR DESCRIPTION
The `eslint-plugin-typescript` project has been moved to
`@typescript-eslint/eslint-plugin` and the old repo has been deprecated.
Related projects such as the TypeScript ESLint parser have also been
moved to the `@typescript-eslint` namespace: https://eslint.org/blog/2019/01/future-typescript-eslint