### PR TITLE
Fixes #41 Turn off base no-unused-vars for TypeScript files

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,6 +262,7 @@ module.exports = {
             'no-undef': 'off',
             // The standard ESLint `no-unused-vars' rule will throw false positives with
             // class properties in TypeScript. The TypeScript-specific rule fixes this.
+            'no-unused-vars': 'off',
             '@typescript-eslint/no-unused-vars': 'error',
             // new-cap throws errors with property decorators
             'new-cap': 'off',


### PR DESCRIPTION
Originally, the TypeScript no-unused-vars rule relied on the base
no-unused-vars rule to be on. This was changed in a later commit and now
we are receiving double errors for unused vars.

This commit turns of the base no-unused-vars rule for TypeScript files.