### PR TITLE
feat: add naming-convention rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,14 +285,12 @@ module.exports = {
             'no-empty-function': [ 'error', { 'allow': [ 'constructors' ] } ],
 
             '@typescript-eslint/adjacent-overload-signatures': 'error',
-            '@typescript-eslint/class-name-casing': 'error',
             '@typescript-eslint/explicit-function-return-type': [ 'error', { 'allowExpressions': true } ],
             '@typescript-eslint/explicit-member-accessibility': 'error',
             '@typescript-eslint/member-delimiter-style': 'error',
             '@typescript-eslint/consistent-type-assertions': [ 'error', { 'assertionStyle': 'as' } ],
             '@typescript-eslint/no-array-constructor': 'error',
             '@typescript-eslint/no-namespace': 'error',
-            '@typescript-eslint/member-naming': [ 'error', { 'private': '^_', 'protected': '^_' } ],
             '@typescript-eslint/member-ordering': 'error',
             '@typescript-eslint/no-non-null-assertion': 'error',
             '@typescript-eslint/no-parameter-properties': [ 'error', { 'allows': [ 'private' ] } ],
@@ -316,6 +314,58 @@ module.exports = {
                {
                   'functions': false,
                   'typedefs': false,
+               },
+            ],
+
+            '@typescript-eslint/no-type-alias': [
+               'error',
+               {
+                  'allowAliases': 'in-unions-and-intersections',
+                  'allowCallbacks': 'always',
+                  'allowMappedTypes': 'always',
+               },
+            ],
+
+            // Disable ESLint's camelcase so we can override with our own
+            // naming convention rules.
+            'camelcase': 'off',
+
+            '@typescript-eslint/naming-convention': [
+               'error',
+               {
+                  selector: 'default',
+                  format: [ 'camelCase' ],
+               },
+               {
+                  selector: 'variable',
+                  format: [ 'camelCase', 'UPPER_CASE' ],
+               },
+               {
+                  selector: 'parameter',
+                  format: [ 'camelCase' ],
+                  leadingUnderscore: 'allow',
+               },
+               {
+                  selector: 'memberLike',
+                  modifiers: [ 'private' ],
+                  format: [ 'camelCase', 'snake_case' ],
+                  leadingUnderscore: 'require',
+               },
+               {
+                  selector: 'typeLike',
+                  format: [ 'PascalCase' ],
+               },
+               {
+                  selector: 'memberLike',
+                  format: [ 'snake_case' ],
+                  leadingUnderscore: 'forbid',
+                  modifiers: [ 'static', 'public' ],
+               },
+               {
+                  selector: 'memberLike',
+                  format: [ 'snake_case' ],
+                  modifiers: [ 'static', 'private' ],
+                  leadingUnderscore: 'require',
                },
             ],
          },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3627,9 +3627,9 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "requires": {
             "lru-cache": "^6.0.0"
           }


### PR DESCRIPTION
- upgrades @typescript-eslint dependencies to 3.10.1
- removes deprecated + deleted rules (see [3.x release notes](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v3.0.0))
- adds [naming-convention](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md) rule

I made a [POC repo](https://github.com/pbredenberg/hey-lets-test-eslint-rules/blob/main/src/Example.ts)  with these rules configured if anyone wants to play with the new settings. I’d appreciate another set of eyes for anything I missed as regards the removal of the leading underscore enforcement (since it's supported with `naming-convention`).