### PR TITLE
Put @silvermine/eslint-plugin-silvermine in main dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1378,7 +1378,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@silvermine/eslint-plugin-silvermine/-/eslint-plugin-silvermine-2.4.0.tgz",
       "integrity": "sha512-6AElLevrwzud9ExV6kHPfQ7pdE2VOTjfyBbzU0UojerB4nNMvQLNlvCm6OQeF70RzXvdArSkAGzPx3LZMSdk1A==",
-      "dev": true,
       "requires": {
         "class.extend": "0.9.1",
         "lodash.assign": "4.2.0",
@@ -2197,8 +2196,7 @@
     "class.extend": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/class.extend/-/class.extend-0.9.1.tgz",
-      "integrity": "sha512-Tzj+2kAkZs+iGiUOUoKvtj4c/SjeVdKZXg/NbLTGKu0kp66h69dyMHQwOSzuyIghXAUswuY24TZc0HdaJCXx2A==",
-      "dev": true
+      "integrity": "sha512-Tzj+2kAkZs+iGiUOUoKvtj4c/SjeVdKZXg/NbLTGKu0kp66h69dyMHQwOSzuyIghXAUswuY24TZc0HdaJCXx2A=="
     },
     "cli-width": {
       "version": "2.2.0",
@@ -5657,8 +5655,7 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
-      "dev": true
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -7947,8 +7944,7 @@
     "underscore": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
-      "dev": true
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "unified": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   },
   "homepage": "https://github.com/silvermine/eslint-config-silvermine#readme",
   "dependencies": {
+    "@silvermine/eslint-plugin-silvermine": "2.4.0",
     "@typescript-eslint/eslint-plugin": "5.17.0",
     "@typescript-eslint/parser": "5.17.0",
     "eslint-plugin-vue": "8.7.1",
     "typescript": "4.6.3"
   },
   "devDependencies": {
-    "@silvermine/eslint-plugin-silvermine": "2.4.0",
     "@silvermine/standardization": "2.0.0",
     "cz-conventional-changelog": "3.0.2",
     "eslint": "8.16.0",


### PR DESCRIPTION
By putting @silvermine/eslint-plugin-silvermine in `dependencies` and not `devDependencies`, this package can be pulled into a project without needing to explicitly include eslint-plugin-silvermine as well.