### PR TITLE
fix: vue/multi-word-component-names should be universal

### DIFF
--- a/partials/vue.js
+++ b/partials/vue.js
@@ -42,6 +42,7 @@ const silvermineRulesUniversal = {
    'vue/html-quotes': [ 'error', 'double' ],
    'vue/html-self-closing': 'error',
    'vue/max-attributes-per-line': 'off',
+   'vue/multi-word-component-names': 'off',
    'vue/multiline-html-element-content-newline': 'error',
    'vue/mustache-interpolation-spacing': 'error',
    'vue/no-multi-spaces': 'error',
@@ -174,7 +175,6 @@ const silvermineRulesVue2Only = {};
 
 const silvermineRulesVue3Only = {
    'vue/no-deprecated-v-is': 'error',
-   'vue/multi-word-component-names': 'off',
    'vue/v-on-event-hyphenation': [ 'error', 'never' ],
 };
 


### PR DESCRIPTION
The vue/multi-word-component-names rule is applied to both Vue 2 and Vue 3 versions of the eslint-plugin-vue package for essential, recommended, and strongly recommended rule sets. So, when we disable this rule, it should be for both Vue 2 and Vue 3.

Ref: https://eslint.vuejs.org/rules/multi-word-component-names.html