### PR TITLE
feat: fine tune naming conventions

### DIFF
--- a/index.js
+++ b/index.js
@@ -324,6 +324,23 @@ module.exports = {
                },
                {
                   selector: 'classProperty',
+                  modifiers: [ 'private', 'readonly', 'static' ],
+                  format: [ 'UPPER_CASE' ],
+                  leadingUnderscore: 'require',
+               },
+               {
+                  selector: 'classProperty',
+                  modifiers: [ 'protected', 'readonly', 'static' ],
+                  format: [ 'UPPER_CASE' ],
+                  leadingUnderscore: 'require',
+               },
+               {
+                  selector: 'classProperty',
+                  modifiers: [ 'public', 'readonly', 'static' ],
+                  format: [ 'UPPER_CASE' ],
+               },
+               {
+                  selector: 'classProperty',
                   modifiers: [ 'protected', 'static' ],
                   format: [ 'snake_case' ],
                   leadingUnderscore: 'require',
@@ -344,11 +361,11 @@ module.exports = {
                },
                {
                   selector: 'variable',
-                  format: [ 'camelCase' ],
+                  format: [ 'camelCase', 'PascalCase' ],
                },
                {
                   selector: 'parameter',
-                  format: [ 'camelCase' ],
+                  format: [ 'camelCase', 'PascalCase' ],
                   leadingUnderscore: 'allow',
                },
                {

--- a/test-cases/typescript/SmallClass.ts
+++ b/test-cases/typescript/SmallClass.ts
@@ -1,0 +1,11 @@
+export class SmallClass {
+   private readonly _helloThere: string;
+
+   public constructor(hello: string) {
+      this._helloThere = hello;
+   }
+
+   public sayHello(): string {
+      return this._helloThere;
+   }
+}

--- a/test-cases/typescript/TestClass.ts
+++ b/test-cases/typescript/TestClass.ts
@@ -1,12 +1,20 @@
+import { SmallClass } from './SmallClass';
+
 /**
  * Test class that adheres to our ESLint rules for TypeScript
  * @param test
  */
 export class TestClass {
 
+   public static readonly BANANA_SWEETNESS: string;
+
+   protected static readonly _BANANA_RIPENESS: string;
+
    protected static _banana_sweetness: string;
 
    private static _apple_type: string;
+
+   private static readonly _APPLE_COLOR: string;
 
    private readonly _appleColor: string;
 
@@ -26,6 +34,12 @@ export class TestClass {
 
    public getApple(): string {
       return TestClass.get_apple_type();
+   }
+
+   public provideSmallClass(Small: new (...args) => SmallClass): string {
+      const MySmallClass = new Small('Hello there!');
+
+      return MySmallClass.sayHello();
    }
 
    protected _getBananaSweetness(): string {


### PR DESCRIPTION
- Adds additional enforcements for read-only constants
- Allows PascalCase for function arguments that are class constructors
- Allows PascalCase for variables assigned to class constructors

Closes #92