### PR TITLE
fix: remove invalid member-ordering value

### DIFF
--- a/index.js
+++ b/index.js
@@ -407,7 +407,6 @@ module.exports = {
 
                      'public-abstract-field',
                      'protected-abstract-field',
-                     'private-abstract-field',
 
                      'public-field',
                      'protected-field',
@@ -437,7 +436,6 @@ module.exports = {
 
                      [ 'public-abstract-method', 'public-abstract-get', 'public-abstract-set' ],
                      [ 'protected-abstract-method', 'protected-abstract-get', 'protected-abstract-set' ],
-                     [ 'private-abstract-method', 'private-abstract-get', 'private-abstract-set' ],
 
                      'public-method',
                      'protected-method',


### PR DESCRIPTION
On 12/5/22 [invalid values for @typescript-eslint/member-ordering were removed](https://github.com/typescript-eslint/typescript-eslint/pull/6164/files) that we have maintained in our config. This removes the invalid values related to
"private" abstract class members. Obviously, a private member in a class cannot be an abstract field. 😂 