### PR TITLE
config: use "ecmaVersion: latest"

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,7 @@ module.exports = {
    ],
 
    'parserOptions': {
-      // Setting the ecmaVersion to 2019 allows ESLint to parse any file that has valid
-      // syntax, even if we use things like spread and rest syntax. It would be nice to
-      // set this to something like 'latest', but you must specify a specific version.
-      'ecmaVersion': 2019,
+      'ecmaVersion': 'latest',
    },
 
    'env': {


### PR DESCRIPTION
In [eslint 7.30.0][1], support for `latest` was added to "ecmaVersion". Switching to `latest` prevents parsing errors when linting newer syntax (e.g. nullish coalescing operators) in JS files.

[1]: https://eslint.org/blog/2021/07/eslint-v7.30.0-released/