### PR TITLE
fix: default ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 # Editor files
 .vscode
 .idea
+
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@
 
 'use strict';
 
-const base = require('./partials/base'),
+const ignores = require('./partials/ignores'),
+      base = require('./partials/base'),
       javascript = require('./partials/javascript'),
       typescript = require('./partials/typescript'),
       vueConfig = require('./partials/vue'),
@@ -22,6 +23,7 @@ const base = require('./partials/base'),
 
 module.exports = [
    esLint.configs.recommended,
+   ignores,
    base,
    ...typescriptESLint.configs.recommended,
    {

--- a/partials/base.js
+++ b/partials/base.js
@@ -1,15 +1,6 @@
 const esLintPluginSilvermine = require('@silvermine/eslint-plugin-silvermine');
 
 module.exports = {
-   ignores: [
-      'cdk.out',
-      // ESLint by default ignores directories with dot prefixes. Some of our
-      // projects use VuePress which maintains its source code in a
-      // `.vuepress` directory. This negated ignore pattern enables linting
-      // for any projects using our config.
-      '!.vuepress',
-   ],
-
    plugins: {
       '@silvermine/eslint-plugin-silvermine': esLintPluginSilvermine, // Our custom rules
    },

--- a/partials/ignores.js
+++ b/partials/ignores.js
@@ -1,0 +1,12 @@
+module.exports = {
+   ignores: [
+      '**/cdk.out/**',
+      '**/.esbuild/**',
+      '**/dist/**',
+      // ESLint by default ignores directories with dot prefixes. Some of our
+      // projects use VuePress which maintains its source code in a
+      // `.vuepress` directory. This negated ignore pattern enables linting
+      // for any projects using our config.
+      '!.vuepress',
+   ],
+};


### PR DESCRIPTION
In the transition to flat config, I didn't notice this detail [from the 8.57 docs](https://eslint.org/docs/v8.x/use/configure/configuration-files-new#globally-ignoring-files-with-ignores):

> If ignores is used **without any other keys in the configuration object,** then the patterns act as global ignores.

Ignores were previously added inside a configuration object that was shared with other properties, so ESLint did not apply them globally.

This PR breaks ignores out into their own file. By keeping ignores in their own file, we will hopefully avoid a similar mistake in the future.

This also removes a DS_Store file and ignores like files.