### PR TITLE
config: migrate indent to stylistic

### DIFF
--- a/partials/base.js
+++ b/partials/base.js
@@ -26,7 +26,7 @@ module.exports = {
          'error', '1tbs', { 'allowSingleLine': false, 'allowSingleLineArrow': true },
       ],
       '@silvermine/eslint-plugin-silvermine/max-statements-per-line': 'error',
-      'indent': [ 'error', 3, { 'VariableDeclarator': 'first', 'SwitchCase': 1 } ],
+      '@stylistic/indent': [ 'error', 3, { 'VariableDeclarator': 'first', 'SwitchCase': 1 } ],
       '@stylistic/comma-dangle': [
          'error',
          {


### PR DESCRIPTION
## Depends on:
https://github.com/silvermine/eslint-config-silvermine/pull/111
https://github.com/silvermine/eslint-config-silvermine/pull/115

## Description
Base partial doen’t specify typescript specific rules, so the indent rule didn’t support typescript syntax. Now that we use the unified stylistic eslint plugin, this rule correctly support ts and js syntaxes by default, so some changes in behavior may be noticed. 
Since this rule was defined using only eslint, not typescript-eslint, in some cases it was not being validated. 

Also, [this rule is known to be broken](https://github.com/typescript-eslint/typescript-eslint/issues/1824) (currently, the docs reference this same issue: https://eslint.style/rules/default/indent#ts-indent), even more for ts syntax. 

For those reasons, some places may start to raise errors. but most of them are expected.