### PR TITLE
config: migrate comma-dangle to stylistic

### DIFF
--- a/partials/base.js
+++ b/partials/base.js
@@ -27,13 +27,14 @@ module.exports = {
       ],
       '@silvermine/eslint-plugin-silvermine/max-statements-per-line': 'error',
       'indent': [ 'error', 3, { 'VariableDeclarator': 'first', 'SwitchCase': 1 } ],
-      'comma-dangle': [
+      '@stylistic/comma-dangle': [
          'error',
          {
             'arrays': 'always-multiline',
             'objects': 'always-multiline',
             'imports': 'always-multiline',
             'exports': 'always-multiline',
+            'enums': 'always-multiline',
             'functions': 'never',
          },
       ],


### PR DESCRIPTION
## Depends on:
https://github.com/silvermine/eslint-config-silvermine/pull/111
https://github.com/silvermine/eslint-config-silvermine/pull/115

## Details
We majorly allow the last element of an enum to have a trailing comma, so, for that reason, this PR specifically defines this as one our rule behaviors. This rule was not enforced for ts syntax, so now that it is, some little changes are needed in the projects that use it