### PR TITLE
config: migrate max-len to stylistic

### DIFF
--- a/partials/base.js
+++ b/partials/base.js
@@ -141,7 +141,7 @@ module.exports = {
       'lines-around-comment': 'error',
       'spaced-comment': [ 'error', 'always' ],
       'max-depth': [ 'error', 4 ],
-      'max-len': [
+      '@stylistic/max-len': [
          'error',
          {
             'code': 140,


### PR DESCRIPTION
## Depends on:
https://github.com/silvermine/eslint-config-silvermine/pull/111
https://github.com/silvermine/eslint-config-silvermine/pull/115

## Details
This has a PR to itself just because this rule caused many changes when applied, but there is not really a change to it besides being migrated to stylistic.