### PR TITLE
config: migrate to stylistic eslint rules with observed impact

### DIFF
--- a/partials/base.js
+++ b/partials/base.js
@@ -159,7 +159,7 @@ module.exports = {
          { 'capIsNewExceptions': [ 'Q' ] },
       ],
       '@stylistic/new-parens': 'error',
-      'padding-line-between-statements': [
+      '@stylistic/padding-line-between-statements': [
          'error',
          { blankLine: 'always', prev: [ 'var', 'let', 'const' ], next: '*' },
       ],

--- a/partials/base.js
+++ b/partials/base.js
@@ -75,7 +75,7 @@ module.exports = {
       'no-labels': 'error',
       'no-lone-blocks': 'error',
       'no-loop-func': 'error',
-      'no-multi-spaces': 'error',
+      '@stylistic/no-multi-spaces': 'error',
       'no-multi-str': 'error',
       'no-new': 'error',
       'no-new-func': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -214,7 +214,7 @@ module.exports = {
          },
       ],
       '@stylistic/space-in-parens': [ 'error', 'never' ],
-      'space-infix-ops': 'error',
+      '@stylistic/space-infix-ops': 'error',
       '@stylistic/space-unary-ops': 'error',
       'unicode-bom': 'error',
       'arrow-body-style': [ 'error', 'always' ],

--- a/partials/base.js
+++ b/partials/base.js
@@ -122,7 +122,7 @@ module.exports = {
       'no-process-exit': 'error',
       'no-sync': 'error',
       '@stylistic/array-bracket-spacing': [ 'error', 'always' ],
-      'block-spacing': 'error',
+      '@stylistic/block-spacing': 'error',
       'camelcase': 'error',
       '@stylistic/comma-spacing': 'error',
       '@stylistic/comma-style': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -202,7 +202,7 @@ module.exports = {
       'one-var': [ 'error', { 'var': 'always', 'let': 'consecutive' } ],
       '@stylistic/one-var-declaration-per-line': 'error',
       '@stylistic/quotes': [ 'error', 'single' ],
-      'semi': [ 'error', 'always' ],
+      '@stylistic/semi': [ 'error', 'always' ],
       '@stylistic/semi-spacing': 'error',
       '@stylistic/space-before-blocks': 'error',
       '@stylistic/space-before-function-paren': [

--- a/partials/base.js
+++ b/partials/base.js
@@ -198,7 +198,7 @@ module.exports = {
       '@stylistic/no-trailing-spaces': 'error',
       'no-unneeded-ternary': 'error',
       '@stylistic/no-whitespace-before-property': 'error',
-      'object-curly-spacing': [ 'error', 'always' ],
+      '@stylistic/object-curly-spacing': [ 'error', 'always' ],
       'one-var': [ 'error', { 'var': 'always', 'let': 'consecutive' } ],
       '@stylistic/one-var-declaration-per-line': 'error',
       '@stylistic/quotes': [ 'error', 'single' ],


### PR DESCRIPTION
## Depends on:
#115 

## Description
After migrating these rules to stylistic, the project where they were tested started raising lint errors. So I've put them together to possibly bring them to attention, but it doesn't mean that these rules will raise errors for all projects.

