### PR TITLE
config: migrate to stylistic eslint rules without observed impact 

### DIFF
--- a/partials/base.js
+++ b/partials/base.js
@@ -204,7 +204,7 @@ module.exports = {
       'semi': [ 'error', 'always' ],
       '@stylistic/semi-spacing': 'error',
       '@stylistic/space-before-blocks': 'error',
-      'space-before-function-paren': [
+      '@stylistic/space-before-function-paren': [
          'error',
          {
             'anonymous': 'never',

--- a/partials/base.js
+++ b/partials/base.js
@@ -124,7 +124,7 @@ module.exports = {
       'block-spacing': 'error',
       'camelcase': 'error',
       '@stylistic/comma-spacing': 'error',
-      'comma-style': 'error',
+      '@stylistic/comma-style': 'error',
       'computed-property-spacing': 'error',
       'consistent-this': [ 'error', 'self' ],
       'eol-last': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -193,7 +193,7 @@ module.exports = {
          'YieldExpression',
       ],
       'no-setter-return': 'error',
-      'func-call-spacing': 'error',
+      '@stylistic/func-call-spacing': 'error',
       'no-trailing-spaces': 'error',
       'no-unneeded-ternary': 'error',
       'no-whitespace-before-property': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -99,7 +99,7 @@ module.exports = {
       'no-with': 'error',
       'radix': 'error',
       'vars-on-top': 'error',
-      'wrap-iife': 'error',
+      '@stylistic/wrap-iife': 'error',
       'yoda': 'error',
       // because we are still on commonjs module
       'strict': 'off',

--- a/partials/base.js
+++ b/partials/base.js
@@ -127,7 +127,7 @@ module.exports = {
       '@stylistic/comma-style': 'error',
       '@stylistic/computed-property-spacing': 'error',
       'consistent-this': [ 'error', 'self' ],
-      'eol-last': 'error',
+      '@stylistic/eol-last': 'error',
       'key-spacing': 'error',
       'keyword-spacing': [
          'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -220,6 +220,6 @@ module.exports = {
       '@stylistic/arrow-spacing': [ 'error', { 'before': true, 'after': true } ],
       '@stylistic/arrow-parens': 'error',
       '@stylistic/template-curly-spacing': [ 'error', 'never' ],
-      'object-property-newline': [ 'error', { 'allowAllPropertiesOnSameLine': true } ],
+      '@stylistic/object-property-newline': [ 'error', { 'allowAllPropertiesOnSameLine': true } ],
    },
 };

--- a/partials/base.js
+++ b/partials/base.js
@@ -214,7 +214,7 @@ module.exports = {
       ],
       '@stylistic/space-in-parens': [ 'error', 'never' ],
       'space-infix-ops': 'error',
-      'space-unary-ops': 'error',
+      '@stylistic/space-unary-ops': 'error',
       'unicode-bom': 'error',
       'arrow-body-style': [ 'error', 'always' ],
       'arrow-spacing': [ 'error', { 'before': true, 'after': true } ],

--- a/partials/base.js
+++ b/partials/base.js
@@ -203,7 +203,7 @@ module.exports = {
       '@stylistic/quotes': [ 'error', 'single' ],
       'semi': [ 'error', 'always' ],
       '@stylistic/semi-spacing': 'error',
-      'space-before-blocks': 'error',
+      '@stylistic/space-before-blocks': 'error',
       'space-before-function-paren': [
          'error',
          {

--- a/partials/base.js
+++ b/partials/base.js
@@ -139,7 +139,7 @@ module.exports = {
       ],
       '@stylistic/linebreak-style': [ 'error', 'unix' ],
       '@stylistic/lines-around-comment': 'error',
-      'spaced-comment': [ 'error', 'always' ],
+      '@stylistic/spaced-comment': [ 'error', 'always' ],
       'max-depth': [ 'error', 4 ],
       'max-len': [
          'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -200,7 +200,7 @@ module.exports = {
       'object-curly-spacing': [ 'error', 'always' ],
       'one-var': [ 'error', { 'var': 'always', 'let': 'consecutive' } ],
       '@stylistic/one-var-declaration-per-line': 'error',
-      'quotes': [ 'error', 'single' ],
+      '@stylistic/quotes': [ 'error', 'single' ],
       'semi': [ 'error', 'always' ],
       'semi-spacing': 'error',
       'space-before-blocks': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -123,7 +123,7 @@ module.exports = {
       '@stylistic/array-bracket-spacing': [ 'error', 'always' ],
       'block-spacing': 'error',
       'camelcase': 'error',
-      'comma-spacing': 'error',
+      '@stylistic/comma-spacing': 'error',
       'comma-style': 'error',
       'computed-property-spacing': 'error',
       'consistent-this': [ 'error', 'self' ],

--- a/partials/base.js
+++ b/partials/base.js
@@ -212,7 +212,7 @@ module.exports = {
             'asyncArrow': 'always',
          },
       ],
-      'space-in-parens': [ 'error', 'never' ],
+      '@stylistic/space-in-parens': [ 'error', 'never' ],
       'space-infix-ops': 'error',
       'space-unary-ops': 'error',
       'unicode-bom': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -137,7 +137,7 @@ module.exports = {
             },
          },
       ],
-      'linebreak-style': [ 'error', 'unix' ],
+      '@stylistic/linebreak-style': [ 'error', 'unix' ],
       'lines-around-comment': 'error',
       'spaced-comment': [ 'error', 'always' ],
       'max-depth': [ 'error', 4 ],

--- a/partials/base.js
+++ b/partials/base.js
@@ -194,7 +194,7 @@ module.exports = {
       ],
       'no-setter-return': 'error',
       '@stylistic/func-call-spacing': 'error',
-      'no-trailing-spaces': 'error',
+      '@stylistic/no-trailing-spaces': 'error',
       'no-unneeded-ternary': 'error',
       'no-whitespace-before-property': 'error',
       'object-curly-spacing': [ 'error', 'always' ],

--- a/partials/base.js
+++ b/partials/base.js
@@ -128,7 +128,7 @@ module.exports = {
       '@stylistic/computed-property-spacing': 'error',
       'consistent-this': [ 'error', 'self' ],
       '@stylistic/eol-last': 'error',
-      'key-spacing': 'error',
+      '@stylistic/key-spacing': 'error',
       'keyword-spacing': [
          'error',
          {

--- a/partials/base.js
+++ b/partials/base.js
@@ -199,7 +199,7 @@ module.exports = {
       '@stylistic/no-whitespace-before-property': 'error',
       'object-curly-spacing': [ 'error', 'always' ],
       'one-var': [ 'error', { 'var': 'always', 'let': 'consecutive' } ],
-      'one-var-declaration-per-line': 'error',
+      '@stylistic/one-var-declaration-per-line': 'error',
       'quotes': [ 'error', 'single' ],
       'semi': [ 'error', 'always' ],
       'semi-spacing': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -218,7 +218,7 @@ module.exports = {
       'unicode-bom': 'error',
       'arrow-body-style': [ 'error', 'always' ],
       '@stylistic/arrow-spacing': [ 'error', { 'before': true, 'after': true } ],
-      'arrow-parens': 'error',
+      '@stylistic/arrow-parens': 'error',
       'template-curly-spacing': [ 'error', 'never' ],
       'object-property-newline': [ 'error', { 'allowAllPropertiesOnSameLine': true } ],
    },

--- a/partials/base.js
+++ b/partials/base.js
@@ -44,7 +44,7 @@ module.exports = {
       'curly': 'error',
       'default-case': 'error',
       'default-param-last': 'error',
-      'dot-location': [ 'error', 'property' ],
+      '@stylistic/dot-location': [ 'error', 'property' ],
       'dot-notation': [
          'error',
          { 'allowPattern': '^[a-z]+(_[a-z]+)+$' }, // Allow obj['snake_case']

--- a/partials/base.js
+++ b/partials/base.js
@@ -219,7 +219,7 @@ module.exports = {
       'arrow-body-style': [ 'error', 'always' ],
       '@stylistic/arrow-spacing': [ 'error', { 'before': true, 'after': true } ],
       '@stylistic/arrow-parens': 'error',
-      'template-curly-spacing': [ 'error', 'never' ],
+      '@stylistic/template-curly-spacing': [ 'error', 'never' ],
       'object-property-newline': [ 'error', { 'allowAllPropertiesOnSameLine': true } ],
    },
 };

--- a/partials/base.js
+++ b/partials/base.js
@@ -157,7 +157,7 @@ module.exports = {
          'error',
          { 'capIsNewExceptions': [ 'Q' ] },
       ],
-      'new-parens': 'error',
+      '@stylistic/new-parens': 'error',
       'padding-line-between-statements': [
          'error',
          { blankLine: 'always', prev: [ 'var', 'let', 'const' ], next: '*' },

--- a/partials/base.js
+++ b/partials/base.js
@@ -168,7 +168,7 @@ module.exports = {
       'no-import-assign': 'error',
       'no-dupe-else-if': 'error',
       'no-lonely-if': 'error',
-      'no-multiple-empty-lines': [
+      '@stylistic/no-multiple-empty-lines': [
          'error',
          {
             'max': 2,

--- a/partials/base.js
+++ b/partials/base.js
@@ -66,7 +66,7 @@ module.exports = {
       'no-extra-bind': 'error',
       'no-extra-label': 'error',
       'no-fallthrough': 'error',
-      'no-floating-decimal': 'error',
+      '@stylistic/no-floating-decimal': 'error',
       'no-implicit-coercion': [ 'error', { 'allow': [ '!!' ] } ],
       'no-implicit-globals': [ 'error', { 'lexicalBindings': true } ],
       'no-implied-eval': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -129,7 +129,7 @@ module.exports = {
       'consistent-this': [ 'error', 'self' ],
       '@stylistic/eol-last': 'error',
       '@stylistic/key-spacing': 'error',
-      'keyword-spacing': [
+      '@stylistic/keyword-spacing': [
          'error',
          {
             'overrides': {

--- a/partials/base.js
+++ b/partials/base.js
@@ -120,7 +120,7 @@ module.exports = {
       'no-process-env': 'error',
       'no-process-exit': 'error',
       'no-sync': 'error',
-      'array-bracket-spacing': [ 'error', 'always' ],
+      '@stylistic/array-bracket-spacing': [ 'error', 'always' ],
       'block-spacing': 'error',
       'camelcase': 'error',
       'comma-spacing': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -138,7 +138,7 @@ module.exports = {
          },
       ],
       '@stylistic/linebreak-style': [ 'error', 'unix' ],
-      'lines-around-comment': 'error',
+      '@stylistic/lines-around-comment': 'error',
       'spaced-comment': [ 'error', 'always' ],
       'max-depth': [ 'error', 4 ],
       'max-len': [

--- a/partials/base.js
+++ b/partials/base.js
@@ -125,7 +125,7 @@ module.exports = {
       'camelcase': 'error',
       '@stylistic/comma-spacing': 'error',
       '@stylistic/comma-style': 'error',
-      'computed-property-spacing': 'error',
+      '@stylistic/computed-property-spacing': 'error',
       'consistent-this': [ 'error', 'self' ],
       'eol-last': 'error',
       'key-spacing': 'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -202,7 +202,7 @@ module.exports = {
       '@stylistic/one-var-declaration-per-line': 'error',
       '@stylistic/quotes': [ 'error', 'single' ],
       'semi': [ 'error', 'always' ],
-      'semi-spacing': 'error',
+      '@stylistic/semi-spacing': 'error',
       'space-before-blocks': 'error',
       'space-before-function-paren': [
          'error',

--- a/partials/base.js
+++ b/partials/base.js
@@ -217,7 +217,7 @@ module.exports = {
       '@stylistic/space-unary-ops': 'error',
       'unicode-bom': 'error',
       'arrow-body-style': [ 'error', 'always' ],
-      'arrow-spacing': [ 'error', { 'before': true, 'after': true } ],
+      '@stylistic/arrow-spacing': [ 'error', { 'before': true, 'after': true } ],
       'arrow-parens': 'error',
       'template-curly-spacing': [ 'error', 'never' ],
       'object-property-newline': [ 'error', { 'allowAllPropertiesOnSameLine': true } ],

--- a/partials/base.js
+++ b/partials/base.js
@@ -196,7 +196,7 @@ module.exports = {
       '@stylistic/func-call-spacing': 'error',
       '@stylistic/no-trailing-spaces': 'error',
       'no-unneeded-ternary': 'error',
-      'no-whitespace-before-property': 'error',
+      '@stylistic/no-whitespace-before-property': 'error',
       'object-curly-spacing': [ 'error', 'always' ],
       'one-var': [ 'error', { 'var': 'always', 'let': 'consecutive' } ],
       'one-var-declaration-per-line': 'error',


### PR DESCRIPTION
## Depends on:
#115 

## Description
After migrating these rules to stylistic, these rules didn't raise any linting errors in the project the changes were tested. I doesn't mean that this will be the case for every project, but based in my testing sample, the likelyhood is lower.

