### PR TITLE
config: migrate typescript partial eslint rules

### DIFF
--- a/partials/typescript.js
+++ b/partials/typescript.js
@@ -217,10 +217,5 @@ module.exports = {
             'typedefs': false,
          },
       ],
-
-      // Replace eslint space-infix-ops with equivalent typescript-eslint rule to support
-      // linting type definitions
-      'space-infix-ops': 'off',
-      '@typescript-eslint/space-infix-ops': [ 'error' ],
    },
 };


### PR DESCRIPTION
## Depends on:
https://github.com/silvermine/eslint-config-silvermine/pull/115

## Description
Migrate possible typescript partial rules to stylistic.
